### PR TITLE
Update procedure to import self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,41 @@ A docker pod for testing nginx configuration options. Configuration attempts to 
 
 ## Quick Start
 
+### Set Up SSL Certificates
+
+**Generate Certificate:**
+
 Before you start, you will need to generate a self-signed certificate using the script in the repo:
 
 ```
 ./generate_certificate.sh
 ```
+
+**Add Certificate to System Keychain (Mac OS X):**
+
+To make this SSL certificate work with the browser (and not issue warnings about
+a self-signed certificate), add the cert file that was generated
+(`etc/ssl/cert/pod-nginx-test.crt`) to the System Keychain:
+
+```
+# Mac
+sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" etc/ssl/certs/pod-nginx-test.crt
+```
+
+or follow [these instructions](https://deliciousbrains.com/ssl-certificate-authority-for-local-https-development/)
+to add the certificate using the Mac UI.
+
+**Enable Imported Certificates in Browser (Firefox):**
+
+By default Firefox will not trust certificates that have been imported into Keychain.
+To enable Firefox to trust them:
+
+* Open Firefox
+* Type `about:config` in the address bar
+* Type `security.enterprise_roots.enabled`
+* Change that setting from `false` to `true`
+
+### Start Docker Pod
 
 Now start the pod:
 
@@ -22,10 +52,9 @@ docker-compose up -d
 
 To view the page that the web server serves up:
 
-`https://localhost:8443`
-
-This will generate a warning that the certificate is self-signed.
-Accept the warning and continue to the site.
+```
+https://localhost:8443
+```
 
 To stop all docker containers:
 
@@ -47,7 +76,7 @@ expected.
 
 The page is served up on port 8443 and accepts SSL connections only.
 
-You will need to generate a self-signed 
+You will need to generate a self-signed certificate.
 
 You must prefix the address `localhost:8443` with `https://`.
 


### PR DESCRIPTION
Update readme with instructions on importing the generated self-signed certificate and configuring the browser to trust it.